### PR TITLE
reversed order of coordinates representing  holes

### DIFF
--- a/geostructures/structures.py
+++ b/geostructures/structures.py
@@ -215,7 +215,7 @@ class GeoShape(LoggingMixin, DefaultZuluMixin):
         """
         return [
             self.bounding_coords(**kwargs),
-            *[shape.bounding_coords() for shape in self.holes]
+            *[list(reversed(shape.bounding_coords())) for shape in self.holes]
         ]
 
     def set_property(self, key: str, value: Any):
@@ -1122,14 +1122,14 @@ class GeoRing(GeoShape):
             # Shape is really a circle with hole
             return [
                 [*outer_bounds, outer_bounds[0]],
-                [*inner_bounds, inner_bounds[0]],
-                *[shape.bounding_coords(**kwargs) for shape in self.holes]
+                list(reversed([*inner_bounds, inner_bounds[0]])),
+                *[list(reversed(shape.bounding_coords(**kwargs))) for shape in self.holes]
             ]
 
         # Is self-closing
         return [
             [*outer_bounds, *inner_bounds[::-1], outer_bounds[0]],
-            *[shape.bounding_coords(**kwargs) for shape in self.holes]
+            *[list(reversed(shape.bounding_coords(**kwargs))) for shape in self.holes]
         ]
 
     def to_polygon(self, **kwargs):

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -299,9 +299,9 @@ def test_geoshape_vertices():
             (Coordinate(1.0, 0.0), Coordinate(1.0, 0.0))
         ],
         [
-            (Coordinate(0.4, 0.6), Coordinate(0.6, 0.6)),
-            (Coordinate(0.6, 0.6), Coordinate(0.5, 0.4)),
-            (Coordinate(0.5, 0.4), Coordinate(0.4, 0.6)),
+            (Coordinate(0.4, 0.6), Coordinate(0.5, 0.4)),
+            (Coordinate(0.5, 0.4), Coordinate(0.6, 0.6)),
+            (Coordinate(0.6, 0.6), Coordinate(0.4, 0.6)),
             (Coordinate(0.4, 0.6), Coordinate(0.4, 0.6))
         ]
     ]

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -195,7 +195,7 @@ def test_geoshape_to_shapely(geobox):
     polygon = GeoPolygon(outline, hole)
     expected = shapely.geometry.Polygon(
         [x.to_float() for x in outline],
-        holes=[[x.to_float() for x in hole.bounding_coords()]]
+        holes=[list(reversed([x.to_float() for x in hole.bounding_coords()]))]
     )
     assert polygon.to_shapely() == expected
 
@@ -494,7 +494,7 @@ def test_geopolygon_linear_rings():
             Coordinate(1.0, 0.0), Coordinate(0.0, 0.0)
         ],
         [
-            Coordinate(0.5, 0.5), Coordinate(0.5, 0.75), Coordinate(0.75, 0.5),
+            Coordinate(0.5, 0.5), Coordinate(0.75, 0.5), Coordinate(0.5, 0.75),
             Coordinate(0.5, 0.5)
         ]
     ]
@@ -541,7 +541,7 @@ def test_geopolygon_to_wkt():
             Coordinate(0.75, 0.25), Coordinate(0.25, 0.25)
         ])
     )
-    assert polygon.to_wkt() == 'POLYGON((0.0 0.0,0.0 1.0,1.0 1.0,1.0 0.0,0.0 0.0),(0.25 0.25,0.25 0.75,0.75 0.75,0.75 0.25,0.25 0.25))'
+    assert polygon.to_wkt() == 'POLYGON((0.0 0.0,0.0 1.0,1.0 1.0,1.0 0.0,0.0 0.0),(0.25 0.25,0.75 0.25,0.75 0.75,0.25 0.75,0.25 0.25))'
 
 
 def test_geoshape_to_wkt():


### PR DESCRIPTION
Reversed order of coordinates representing holes to conform with geojson right hand rule 