### PR TITLE
Test bounding box first in contains_shape() if shape has 5+ edges

### DIFF
--- a/geostructures/structures.py
+++ b/geostructures/structures.py
@@ -345,8 +345,20 @@ class GeoShape(DefaultZuluMixin):
             bool
         """
 
+        bbox_tested = False
+        if kwargs.get('k', 0) > 4:
+             if self.contains_shape(shape.circumscribing_rectangle()):
+                return True
+             else:
+                 bbox_tested = True
+
         s_edges = self.edges(**kwargs)
         o_edges = shape.edges(**kwargs)
+
+        if not bbox_tested and len(o_edges) > 4:
+            if self.contains_shape(shape.circumscribing_rectangle()):
+                return True
+        
         if do_edges_intersect(
             [x for edge_ring in s_edges for x in edge_ring],
             [x for edge_ring in o_edges for x in edge_ring]

--- a/geostructures/structures.py
+++ b/geostructures/structures.py
@@ -347,10 +347,10 @@ class GeoShape(DefaultZuluMixin):
 
         bbox_tested = False
         if kwargs.get('k', 0) > 4:
-             if self.contains_shape(shape.circumscribing_rectangle()):
+            if self.contains_shape(shape.circumscribing_rectangle()):
                 return True
-             else:
-                 bbox_tested = True
+            else:
+                bbox_tested = True
 
         s_edges = self.edges(**kwargs)
         o_edges = shape.edges(**kwargs)
@@ -358,7 +358,7 @@ class GeoShape(DefaultZuluMixin):
         if not bbox_tested and len(o_edges) > 4:
             if self.contains_shape(shape.circumscribing_rectangle()):
                 return True
-        
+
         if do_edges_intersect(
             [x for edge_ring in s_edges for x in edge_ring],
             [x for edge_ring in o_edges for x in edge_ring]


### PR DESCRIPTION
Contains_shape currently makes m x n comparisons, where m is the number of edges for self and n is the number of edges for shape.  If shape's circumscribing rectangle is contained in self, which we can check with m x 4 comparisons, then we don't need to check m x n.

This code checks whenever n < 4, which will sometimes make it slower than the previous version, but that depends on m even when n=5. The important things to cut out are cases where m and n are both large, which this will do.