### PR TITLE
Geospan for FeatureCollections

### DIFF
--- a/geostructures/collections.py
+++ b/geostructures/collections.py
@@ -358,6 +358,11 @@ class ShapeCollection(DefaultZuluMixin):
 
         return FeatureCollection(shapes)
 
+    @cachedproperty
+    def span(self) -> float:
+        bounds = self.bounds
+        return bounds[0][1] - bounds[0][0] + bounds[1][1] - bounds[1][0]
+
     def intersects(self, shape: GeoShape):
         """
         Boolean determination of whether any pings from the track exist inside the provided

--- a/geostructures/collections.py
+++ b/geostructures/collections.py
@@ -358,7 +358,7 @@ class ShapeCollection(DefaultZuluMixin):
 
         return FeatureCollection(shapes)
 
-    @cachedproperty
+    @cached_property
     def geospan(self) -> float:
         """
         A summary statistic equal to the width of self.bounds in degrees

--- a/geostructures/collections.py
+++ b/geostructures/collections.py
@@ -359,7 +359,12 @@ class ShapeCollection(DefaultZuluMixin):
         return FeatureCollection(shapes)
 
     @cachedproperty
-    def span(self) -> float:
+    def geospan(self) -> float:
+        """
+        A summary statistic equal to the width of self.bounds in degrees
+        plus the height of self.bounds in degrees. Can be used as a quick
+        way to sort larger (in extent) FeatureCollections from smaller ones.
+        """
         bounds = self.bounds
         return bounds[0][1] - bounds[0][0] + bounds[1][1] - bounds[1][0]
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -286,12 +286,12 @@ def test_collection_from_shapely():
     assert FeatureCollection.from_shapely(gcol) == expected
 
 
-def test_collection_span():
+def test_collection_geospan():
     col1 = FeatureCollection([
         GeoBox(Coordinate(-1.1, 0.), Coordinate(0., -5)),
         GeoBox(Coordinate(-0.5, 2.), Coordinate(2., -7)),
     ])
-    assert col1.span == 12.1
+    assert col1.geospan == 12.1
 
 
 def test_collection_to_geojson():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -286,6 +286,14 @@ def test_collection_from_shapely():
     assert FeatureCollection.from_shapely(gcol) == expected
 
 
+def test_collection_span():
+    col1 = FeatureCollection([
+        GeoBox(Coordinate(-1.1, 0.), Coordinate(0., -5)),
+        GeoBox(Coordinate(-0.5, 2.), Coordinate(2., -7)),
+    ])
+    assert col1.span == 12.1
+
+
 def test_collection_to_geojson():
     shapes = [
         GeoBox(Coordinate(0.0, 1.0), Coordinate(1.0, 0.0)),


### PR DESCRIPTION
Added a summary function to separate large FeatureCollections from smaller ones. Geospan of several shapes in defined as the number of degrees of latitude that the bounding box of all collective shapes spans plus the number of degrees of longitude that the bounding box spans.

WARNING: unlike individual GeoShapes, there is no way to tell whether a FeatureCollection is intended to span the International Date Line or not. 