### PR TITLE
ZM Values

### DIFF
--- a/geostructures/_base.py
+++ b/geostructures/_base.py
@@ -14,7 +14,6 @@ from typing import (
 from geostructures.coordinates import Coordinate
 from geostructures.time import TimeInterval, GEOTIME_TYPE
 from geostructures.utils.functions import default_to_zulu, sanitize_json
-from geostructures.utils.logging import LOGGER
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/geostructures/_base.py
+++ b/geostructures/_base.py
@@ -419,11 +419,8 @@ class BaseShape(BaseShapeProtocol, ABC):
             self,
             dt: Optional[GEOTIME_TYPE] = None,
             properties: Optional[Dict] = None,
-            **kwargs
     ):
         super().__init__()
-        if kwargs:
-            LOGGER.warning('Unrecognized kwargs: %s', ', '.join(kwargs.keys()))
         if isinstance(dt, datetime):
             # Convert to a zero-second time interval
             dt = default_to_zulu(dt)

--- a/geostructures/_base.py
+++ b/geostructures/_base.py
@@ -14,6 +14,7 @@ from typing import (
 from geostructures.coordinates import Coordinate
 from geostructures.time import TimeInterval, GEOTIME_TYPE
 from geostructures.utils.functions import default_to_zulu, sanitize_json
+from geostructures.utils.logging import LOGGER
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -21,8 +22,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from geostructures.typing import GeoShape, PolygonLike
 
 
-# A wkt coordinate, e.g. '-1.0 2.0'
-_RE_COORD_STR = r'-?\d{1,3}(?:\.?\d*)?\s-?\d{1,3}(?:\.?\d*)?'
+# A wkt coordinate, e.g. '-1.0 2.0', that can be up to 4 numbers long (can include Z and M)
+_RE_COORD_STR = r'(?:-?\d{1,3}(?:\.?\d*)?\s?){2,4}\s?'
 _RE_COORD = re.compile(_RE_COORD_STR)
 
 # A single linear ring, e.g. '(0.0 0.0, 1.0 1.0, ... )'
@@ -33,24 +34,21 @@ _RE_LINEAR_RING = re.compile(_RE_LINEAR_RING_STR)
 _RE_LINEAR_RINGS_STR = r'(\((?:' + _RE_LINEAR_RING_STR + r'\,?\s?)+\))'
 _RE_LINEAR_RINGS = re.compile(_RE_LINEAR_RINGS_STR)
 
-_RE_POINT_WKT = re.compile(r'POINT\s?\(\s?' + _RE_COORD_STR + r'\s?\)')
-_RE_POLYGON_WKT = re.compile(r'POLYGON\s?' + _RE_LINEAR_RINGS_STR)
-_RE_LINESTRING_WKT = re.compile(r'LINESTRING\s?' + _RE_LINEAR_RING_STR)
+_RE_ZM_STR = r'\s?([ZM]{0,2})\s?'  # Presence is optional - for matching whole WKT
+_RE_ZM = re.compile(r'\s?([ZM]{1,2})\s?')  # Presence is required - for matching ZM specifically
 
-_RE_MULTIPOINT_WKT = re.compile(r'MULTIPOINT\s?' + _RE_LINEAR_RING_STR)
-_RE_MULTIPOLYGON_WKT = re.compile(r'MULTIPOLYGON\s?\((' + _RE_LINEAR_RINGS_STR + r',?\s?)+\)')
-_RE_MULTILINESTRING_WKT = re.compile(r'MULTILINESTRING\s?' + _RE_LINEAR_RINGS_STR)
+_RE_POINT_WKT = re.compile(r'^POINT' + _RE_ZM_STR + r'\(\s?' + _RE_COORD_STR + r'\s?\)$')
+_RE_POLYGON_WKT = re.compile(r'^POLYGON' + _RE_ZM_STR + _RE_LINEAR_RINGS_STR + '$')
+_RE_LINESTRING_WKT = re.compile(r'^LINESTRING' + _RE_ZM_STR + _RE_LINEAR_RING_STR + '$')
+
+_RE_MULTIPOINT_WKT = re.compile(r'^MULTIPOINT' + _RE_ZM_STR + _RE_LINEAR_RING_STR + '$')
+_RE_MULTIPOLYGON_WKT = re.compile(
+    r'^MULTIPOLYGON' + _RE_ZM_STR + r'\((' + _RE_LINEAR_RINGS_STR + r',?\s?)+\)$'
+)
+_RE_MULTILINESTRING_WKT = re.compile(r'^MULTILINESTRING' + _RE_ZM_STR + _RE_LINEAR_RINGS_STR + '$')
 
 
 SHAPE_VAR = TypeVar('SHAPE_VAR', bound='BaseShapeProtocol')
-
-
-def parse_wkt_linear_ring(group: str) -> List[Coordinate]:
-    """Parse wkt coordinate list into Coordinate objects"""
-    return [
-        Coordinate(*coord.strip().split(' '))  # type: ignore
-        for coord in group.strip('()').split(',') if coord
-    ]
 
 
 class BaseShapeProtocol(Protocol):
@@ -134,6 +132,30 @@ class BaseShapeProtocol(Protocol):
             The wkt-formatted string,
         """
         return f'({",".join(" ".join(coord.to_str()) for coord in ring)})'
+
+    @staticmethod
+    def _parse_wkt_linear_ring(wkt_str: str, wkt_coords: str):
+        """
+        Parses a WKT coordinate string, e.g. "1.0 2.0, 3.0 4.0, ..." into
+        geostructures Coordinates. If Z/M values are present, inserts them into
+        the dictionary returned in the second element.
+
+        This method assumes the WKT string has already been validated.
+
+        Args:
+            wkt_str:
+                A WKT geometry, in its entirety.
+
+            wkt_coords:
+                A WKT coordinate list
+
+        Returns:
+            List of Coordinates
+        """
+        coords = _RE_COORD.findall(wkt_coords)
+        zm = _RE_ZM.findall(wkt_str) or ['ZM']
+        parsed_coords = [Coordinate.from_wkt(coord, zm_order=zm[0]) for coord in coords]
+        return parsed_coords
 
     def buffer_dt(
         self: SHAPE_VAR,
@@ -386,9 +408,12 @@ class BaseShape(BaseShapeProtocol, ABC):
     def __init__(
             self,
             dt: Optional[GEOTIME_TYPE] = None,
-            properties: Optional[Dict] = None
+            properties: Optional[Dict] = None,
+            **kwargs
     ):
         super().__init__()
+        if kwargs:
+            LOGGER.warning('Unrecognized kwargs: %s', ', '.join(kwargs.keys()))
         if isinstance(dt, datetime):
             # Convert to a zero-second time interval
             dt = default_to_zulu(dt)

--- a/geostructures/_base.py
+++ b/geostructures/_base.py
@@ -97,6 +97,16 @@ class BaseShapeProtocol(Protocol):
         return self.dt.end
 
     @property
+    @abstractmethod
+    def has_z(self) -> bool:
+        """Determines whether any coordinates in the shape have associated Z values"""
+
+    @property
+    @abstractmethod
+    def has_m(self) -> bool:
+        """Determines whether any coordinates in the shape have associated M values"""
+
+    @property
     def properties(self):
         props = self._properties.copy()
         if self.dt:
@@ -644,6 +654,14 @@ class MultiShapeBase(BaseShape, ABC):
             zip(*[[x for pair in shape.bounds for x in pair] for shape in self.geoshapes])
         )
         return (min(min_lons), max(max_lons)), (min(min_lats), max(max_lats))
+
+    @property
+    def has_m(self) -> bool:
+        return any(x.has_m for x in self.geoshapes)
+
+    @property
+    def has_z(self) -> bool:
+        return any(x.has_z for x in self.geoshapes)
 
     def contains_coordinate(self, coord: Coordinate) -> bool:
         for shape in self.geoshapes:

--- a/geostructures/collections.py
+++ b/geostructures/collections.py
@@ -327,7 +327,9 @@ class ShapeCollection:
 
                 props = record.as_dict()
                 dt = _get_dt(props)
-                props = {k: v for k, v in props.items() if k not in (time_start_field, time_end_field)}
+                props = {
+                    k: v for k, v in props.items() if k not in (time_start_field, time_end_field)
+                }
 
                 shapes.append(
                     geostructs_type.from_pyshp(shape, dt=dt, properties=props)  # type: ignore
@@ -479,8 +481,11 @@ class ShapeCollection:
             elif isinstance(shape, LineLike):
                 lines.append(shape)
 
+            elif isinstance(shape, PolygonLike):
+                shapes.append(shape)
+
             else:
-                shapes.append(cast(PolygonLike, shape))
+                raise ValueError(f'Unrecognized shape type {type(shape)}')
 
         with tempfile.TemporaryDirectory() as tempdir:
             for shapetype, shape_group in (
@@ -494,7 +499,8 @@ class ShapeCollection:
 
                 # 2-Tuples of properties and their datatypes
                 _types = set(
-                    (_key, type(_val)) for x in shape_group
+                    (_key, type(_val))
+                    for x in shape_group
                     for _key, _val in x.properties.items()
                     if (not include_properties) or _key in include_properties
                 )

--- a/geostructures/coordinates.py
+++ b/geostructures/coordinates.py
@@ -6,7 +6,7 @@ __all__ = ['Coordinate']
 
 from functools import cached_property
 import math
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, cast
 
 from geostructures.utils.functions import round_half_up
 from geostructures.utils.logging import warn_once
@@ -50,15 +50,14 @@ class Coordinate:
         return (
             self.latitude == other.latitude and
             self.longitude == other.longitude and
-            self.z == other.z and
-            self.m == other.m
+            self.z == other.z
         )
 
     def __hash__(self):
         return hash((self.longitude, self.latitude, self.z, self.m))
 
     def __repr__(self):
-        parts = filter(bool, (self.longitude, self.latitude, self.z, self.m))
+        parts = filter(lambda x: x is not None, (self.longitude, self.latitude, self.z, self.m))
         return f'<Coordinate({", ".join(map(str, parts))})>'
 
     @cached_property
@@ -189,7 +188,7 @@ class Coordinate:
             )
             zm = dict(zip(list(zm_order.lower()), map(float, parts[2:])))
 
-        return Coordinate(*parts[:2], **zm)
+        return Coordinate(*cast(Tuple[float, float], parts[:2]), z=zm.get('z'), m=zm.get('m'))
 
     def to_dms(self) -> Tuple[Tuple[int, int, float, str], Tuple[int, int, float, str]]:
         """

--- a/geostructures/structures.py
+++ b/geostructures/structures.py
@@ -586,7 +586,7 @@ class GeoPolygon(PolygonBase):
             linear_rings.append(
                 [
                     Coordinate(
-                        *cast(Tuple[float, float],x),
+                        *cast(Tuple[float, float], x),
                         z=z.pop(0) if z else None,
                         m=m.pop(0) if m else None,
                     ) for x in linear_ring
@@ -1443,7 +1443,7 @@ class GeoLineString(SingleShapeBase, LineLikeMixin):
         return GeoLineString(
             [
                 Coordinate(
-                    *cast(Tuple[float, float],x),
+                    *cast(Tuple[float, float], x),
                     z=z.pop(0) if z else None,
                     m=m.pop(0) if m else None,
                 ) for x in shape.__geo_interface__.get('coordinates', [])

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -47,6 +47,13 @@ def test_rotate_coordinates():
         Coordinate(0.707, 0.707),
     ]
 
+    # Preserve Z values
+    points = [
+        Coordinate(1.0, 0.0, z=5.),
+    ]
+    result = rotate_coordinates(points, Coordinate(0.0, 0.0), 45)
+    assert result[0].z == 5.
+
     # Antimeridian test
     points = [
         Coordinate(-179, 0.),

--- a/tests/test_multistructures.py
+++ b/tests/test_multistructures.py
@@ -100,16 +100,16 @@ def test_multigeolinestring_from_geojson():
 def test_multigeolinestring_from_pyshp():
     class MockShape:
         def __init__(self):
-            self.z = [1., 2.]
-            self.m = [3., 4.]
+            self.z = [10., 12., 14., 16.]
+            self.m = [11., 13., 15., 17.]
 
         @property
         def __geo_interface__(self):
             return {
                 'type': 'MultiLineString',
                 'coordinates': [
-                    [[0.0, 1.0, 10., 11.], [1.0, 1.0, 12., 13.]],
-                    [[1.0, 1.0, 14., 15.], [2.0, 2.0, 16., 17.]]
+                    [[0.0, 1.0], [1.0, 1.0]],
+                    [[1.0, 1.0], [2.0, 2.0]]
                 ]
             }
 
@@ -352,7 +352,7 @@ def test_multigeopoint_to_geojson():
     }
 
 
-def test_multigeoshape_to_pyshp():
+def test_multigeopoint_to_pyshp():
     class MockShape:
         def __init__(self):
             self.z = [1., 2.]

--- a/tests/test_multistructures.py
+++ b/tests/test_multistructures.py
@@ -97,6 +97,40 @@ def test_multigeolinestring_from_geojson():
         MultiGeoLineString.from_geojson(gjson)
 
 
+def test_multigeolinestring_from_pyshp():
+    class MockShape:
+        def __init__(self):
+            self.z = [1., 2.]
+            self.m = [3., 4.]
+
+        @property
+        def __geo_interface__(self):
+            return {
+                'type': 'MultiLineString',
+                'coordinates': [
+                    [[0.0, 1.0, 10., 11.], [1.0, 1.0, 12., 13.]],
+                    [[1.0, 1.0, 14., 15.], [2.0, 2.0, 16., 17.]]
+                ]
+            }
+
+    actual = MultiGeoLineString.from_pyshp(
+        MockShape(),
+        dt=datetime(2020, 1, 1),
+        properties={'test': 'prop'}
+    )
+    expected = MultiGeoLineString(
+        [
+            GeoLineString([Coordinate(0., 1., z=10., m=11.), Coordinate(1., 1., z=12., m=13.)]),
+            GeoLineString([Coordinate(1., 1., z=14., m=15.), Coordinate(2., 2., z=16., m=17.)])
+        ],
+        dt=datetime(2020, 1, 1),
+        properties={'test': 'prop'}
+    )
+
+    assert actual == expected
+    assert actual.properties == expected.properties
+
+
 def test_multigeolinestring_from_shapely():
     smls = shapely.MultiLineString([[[0, 0], [1, 2]], [[4, 4], [5, 6]]])
     mls = MultiGeoLineString.from_shapely(smls)
@@ -316,6 +350,30 @@ def test_multigeopoint_to_geojson():
         },
         "test_kwarg": "test_kwarg"
     }
+
+
+def test_multigeoshape_to_pyshp():
+    class MockShape:
+        def __init__(self):
+            self.z = [1., 2.]
+            self.m = [3., 4.]
+
+        @property
+        def __geo_interface__(self):
+            return {'type': 'MultiPoint', 'coordinates': [[0.0, 1.0], [1.0, 1.0]]}
+
+    actual = MultiGeoPoint.from_pyshp(
+        MockShape(),
+        dt=datetime(2020, 1, 1),
+        properties={'test': 'prop'}
+    )
+    expected = MultiGeoPoint(
+        [GeoPoint(Coordinate(0., 1., z=1., m=3.)), GeoPoint(Coordinate(1., 1., z=2., m=4.))],
+        dt=datetime(2020, 1, 1),
+        properties={'test': 'prop'}
+    )
+    assert actual == expected
+    assert actual.properties == expected.properties
 
 
 def test_multigeopoint_to_shapely():

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -628,6 +628,35 @@ def test_geopolygon_from_wkt():
         ])]
     )
 
+    wkt_str = 'POLYGON ZM ((30.123 10 1 2, 40 40 1 2, 20 40 1 2, 10.123 20 1 2, 30.123 10 1 2))'
+    poly = GeoPolygon.from_wkt(wkt_str)
+    assert [x.z for x in poly.outline] == [1., 1., 1., 1., 1.]
+    assert [x.m for x in poly.outline] == [2., 2., 2., 2., 2.]
+
+    # Test varying the ZM order
+    wkt_str = 'POLYGON MZ ((30.123 10 1 2, 40 40 1 2, 20 40 1 2, 10.123 20 1 2, 30.123 10 1 2))'
+    poly = GeoPolygon.from_wkt(wkt_str)
+    assert [x.m for x in poly.outline] == [1., 1., 1., 1., 1.]
+    assert [x.z for x in poly.outline] == [2., 2., 2., 2., 2.]
+
+    # Test missing ZM
+    wkt_str = 'POLYGON ((30.123 10 1 2, 40 40 1 2, 20 40 1 2, 10.123 20 1 2, 30.123 10 1 2))'
+    poly = GeoPolygon.from_wkt(wkt_str)
+    assert [x.z for x in poly.outline] == [1., 1., 1., 1., 1.]
+    assert [x.m for x in poly.outline] == [2., 2., 2., 2., 2.]
+
+    # Test only Z
+    wkt_str = 'POLYGON Z ((30.123 10 1, 40 40 1, 20 40 1, 10.123 20 1, 30.123 10 1))'
+    poly = GeoPolygon.from_wkt(wkt_str)
+    assert [x.z for x in poly.outline] == [1., 1., 1., 1., 1.]
+    assert [x.m for x in poly.outline] == [None, None, None, None, None]
+
+    # Test only M
+    wkt_str = 'POLYGON M ((30.123 10 1, 40 40 1, 20 40 1, 10.123 20 1, 30.123 10 1))'
+    poly = GeoPolygon.from_wkt(wkt_str)
+    assert [x.m for x in poly.outline] == [1., 1., 1., 1., 1.]
+    assert [x.z for x in poly.outline] == [None, None, None, None, None]
+
     with pytest.raises(ValueError):
         _ = GeoPolygon.from_wkt('NOT A POLYGON')
 


### PR DESCRIPTION
Adds support for Z and M values in coordinates.

Adds support for parsing Z/M values from shapefiles, wkt, and geojson (only Z) as well as writing values out to the same.

Adds properties "has_z" and "has_m" to shapes, which will determine whether any component coordinates contain Z or M data.